### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Displays.Led.nuspec
+++ b/MakoIoT.Device.Displays.Led.nuspec
@@ -17,7 +17,7 @@
     <description>LED library for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot led display</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.20" />
       <dependency id="nanoFramework.System.Threading" version="1.1.19" />
     </dependencies>
   </metadata>

--- a/src/MakoIoT.Device.Displays.Led/MakoIoT.Device.Displays.Led.nfproj
+++ b/src/MakoIoT.Device.Displays.Led/MakoIoT.Device.Displays.Led.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="RgbPixel.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.19.33722, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Displays.Led/packages.config
+++ b/src/MakoIoT.Device.Displays.Led/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.14.20</br>
[version update]

### :warning: This is an automated update. :warning:
